### PR TITLE
Using proper struct casting for event header when processing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+* Using proper struct casting for event header when processing.
+* Less copying in the example audio buffer processing.
+
+### Added
+* Logging.
+* Build target for generating intermediary C form.
+* Extended DEBUG flag for tracing all calls.
+
 ## [0.1.1] - 2024-01-17
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 SOURCEDIR = src
 BUILDDIR = build
 TARGET = $(BUILDDIR)/hello_world.clap
+V_CMD = v -cc gcc -shared -enable-globals
 
 # List all V source files
 V_SRC = $(wildcard $(SOURCEDIR)/*.v)
@@ -10,6 +11,9 @@ V_SRC = $(wildcard $(SOURCEDIR)/*.v)
 DEBUG ?= 0
 RELEASE ?= 0
 ifeq ($(DEBUG),1)
+	V_FLAGS = -cg -show-c-output
+else ifeq ($(DEBUG),2)
+	# Even more debug! Very noisy.
 	V_FLAGS = -cg -show-c-output -trace-calls
 else ifeq ($(RELEASE),1)
 	V_FLAGS = -prod -skip-unused -cflags -fvisibility=hidden
@@ -20,7 +24,7 @@ all: $(TARGET)
 
 # Use dependency on V source files to avoid recompilation
 $(TARGET): $(V_SRC) | dir
-	v -cc gcc -shared -enable-globals $(V_FLAGS) $(SOURCEDIR) -o $@.so
+	$(V_CMD) $(V_FLAGS) $(SOURCEDIR) -o $@.so
 ifeq ($(RELEASE),1)
 	strip $@.so
 endif
@@ -34,6 +38,9 @@ clean:
 
 info: $(TARGET)
 	clap-info $<
+
+genc: $(V_SRC) | dir
+	$(V_CMD) $(V_FLAGS) $(SOURCEDIR) -o $(TARGET).c
 
 install: $(TARGET)
 	mkdir -p ~/.clap

--- a/src/c_abi.v
+++ b/src/c_abi.v
@@ -1,5 +1,3 @@
-module plugin
-
 #flag -I./include
 #include "clap/clap.h"
 
@@ -103,8 +101,7 @@ mut:
 struct C.clap_input_events_t {
 	ctx  voidptr
 	size fn (&C.clap_input_events_t) u32
-	// TODO: How to avoid `voidptr` and use header/event structs instead?
-	get fn (&C.clap_input_events_t, u32) voidptr
+	get fn (&C.clap_input_events_t, u32) &C.clap_event_header_t
 }
 
 @[typedef]
@@ -116,9 +113,9 @@ struct C.clap_event_header_t {
 	flags    u32
 }
 
-// TODO: Why doesn't typedef C structs work here?
-struct ClapEventNote {
-	C.clap_event_header_t
+@[typedef]
+struct C.clap_event_note_t {
+	header C.clap_event_header_t
 	note_id    int
 	port_index i16
 	channel    i16

--- a/src/ext_audio_ports.v
+++ b/src/ext_audio_ports.v
@@ -1,5 +1,3 @@
-module plugin
-
 const clap_ext_audio_ports = unsafe { (&char(C.CLAP_EXT_AUDIO_PORTS)).vstring() }
 const clap_port_stereo = unsafe { (&char(C.CLAP_PORT_STEREO)).vstring() }
 const clap_port_mono = unsafe { (&char(C.CLAP_PORT_MONO)).vstring() }

--- a/src/ext_latency.v
+++ b/src/ext_latency.v
@@ -1,5 +1,3 @@
-module plugin
-
 const clap_ext_latency = unsafe { (&char(C.CLAP_EXT_LATENCY)).vstring() }
 
 @[typedef]

--- a/src/ext_note_ports.v
+++ b/src/ext_note_ports.v
@@ -1,5 +1,3 @@
-module plugin
-
 const clap_ext_note_ports = unsafe { (&char(C.CLAP_EXT_NOTE_PORTS)).vstring() }
 
 @[typedef]

--- a/src/main.v
+++ b/src/main.v
@@ -1,5 +1,4 @@
-module plugin
-
+import log
 // Exposes the plugin to the host (DAW).
 
 // This requires modification to `clap/entry.h`.
@@ -7,3 +6,11 @@ module plugin
 // CLAP_EXPORT extern clap_plugin_entry_t clap_entry;
 @[markused]
 __global clap_entry = plugin_entry
+
+fn init() {
+	$if debug {
+		log.set_level(log.Level.debug)
+	} $else {
+		log.set_level(log.Level.info)
+	}
+}

--- a/src/setup.v
+++ b/src/setup.v
@@ -1,5 +1,3 @@
-module plugin
-
 // Features of the CLAP plugin.
 // Have to be defined separately here, otherwise wrong C is generated.
 const _plugin_features = [


### PR DESCRIPTION
Also smaller stuff:

* Added logging; auto-configured at library load.
* Build target for generating intermediary C form.
* Extended `DEBUG` flag for tracing all calls.
* Less copying in the example audio buffer processing.